### PR TITLE
Fixed error of getComputedStyle that occur in 41beta

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -65,9 +65,11 @@ Dom.isVisibleInDisplay = function(element) {
     // box bounding.
     for (var i = 0; i < element.childNodes.length; i++) {
       var child = element.childNodes[i];
-      var style = window.getComputedStyle(child, null);
-      if (style && style.getPropertyValue('float') != 'none' && Dom.isVisibleInDisplay(child)) {
-        return true;
+      if (child && child.nodeName != '#document' && child.nodeName != '#text') {
+        var style = window.getComputedStyle(child, null);
+        if (style && style.getPropertyValue('float') != 'none' && Dom.isVisibleInDisplay(child)) {
+          return true;
+        }
       }
     }
 
@@ -116,6 +118,9 @@ Dom.stayInOverflowHiddenBox = function(element) {
   var fixedElement = undefined;
 
   while (parentNode = parentNode.parentNode) {
+    if (!parentNode || parentNode.nodeName == '#document' || parentNode.nodeName == '#text') {
+      break;
+    }
     computedStyle = window.getComputedStyle(parentNode, null);
     if (!computedStyle) {
       break;


### PR DESCRIPTION
41beta で発生していたgetComputedStyleのエラーを修正しました。

イシューはこちら
https://github.com/tkengo/hometype/issues/42

### 対応
nodeにdocumentとtextが渡ってきたときにエラーになるので、判定をいれて除外するようにしました。