### PR TITLE
Fix the scroll issue

### DIFF
--- a/js/viewport.js
+++ b/js/viewport.js
@@ -9,14 +9,31 @@ var HometypeScreen = function() {
 };
 
 /**
+ * Get the top DOM element which can be scrolled.
+ * Referred to https://dev.opera.com/articles/fixing-the-scrolltop-bug/
+ *
+ * @return (HTMLElement | null) document.scrollingElement or document.body. It depends on an environment.
+ */
+HometypeScreen.prototype.scrollingArea = function() {
+  if ('scrollingElement' in document) {
+    return document.scrollingElement;
+  // Fallback for legacy browsers
+  } else if (navigator.userAgent.indexOf('WebKit') != -1) {
+    return document.body;
+  }
+
+  return document.documentElement;
+}();
+
+/**
  * Get the current scroll position.
  *
  * @return Object A hash that has top and left key.
  */
 HometypeScreen.prototype.getScrollPosition = function() {
   return {
-    top: document.body.scrollTop,
-    left: document.body.scrollLeft
+    top: this.scrollingArea.scrollTop,
+    left: this.scrollingArea.scrollLeft
   };
 };
 
@@ -51,8 +68,8 @@ HometypeScreen.prototype.getDocumentSize = function() {
  * @param integer y vertical position.
  */
 HometypeScreen.prototype.scrollTo = function(x, y) {
-  document.body.scrollTop = y;
-  document.body.scrollLeft = x;
+  this.scrollingArea.scrollTop = y;
+  this.scrollingArea.scrollLeft = x;
 };
 
 /**

--- a/lib/jquery.extend.js
+++ b/lib/jquery.extend.js
@@ -1,11 +1,23 @@
 (function($) {
+  // TODO: Refactor. There is an overlapped code with this in viewport.js.
+  var scrollingArea = function() {
+    if ('scrollingElement' in document) {
+      return document.scrollingElement;
+    // Fallback for legacy browsers
+    } else if (navigator.userAgent.indexOf('WebKit') != -1) {
+      return document.body;
+    }
+
+    return document.documentElement;
+  }();
+
   $.fn.screenCenter = function() {
     return this.each(function() {
       var windowWidth         = window.innerWidth;
       var windowHeight        = window.innerHeight;
       var elementWidth        = $(this).outerWidth();
       var elementHeight       = $(this).outerHeight();
-      var screenOffsetTop     = document.body.scrollTop;
+      var screenOffsetTop     = scrollingArea.scrollTop;
 
       var top  = screenOffsetTop + (windowHeight / 2) - (elementHeight / 2);
       var left =                   (windowWidth  / 2) - (elementWidth  / 2);
@@ -69,7 +81,7 @@
       }
 
       var box = element.getBoundingClientRect();
-      var screenOffsetTop     = document.body.scrollTop;
+      var screenOffsetTop     = scrollingArea.scrollTop;
       var screenOffsetBottom  = screenOffsetTop + window.innerHeight;
       var elementOffsetTop    = box.top + window.pageYOffset - docElem.clientTop;
       var elementOffsetBottom = elementOffsetTop + element.offsetHeight;


### PR DESCRIPTION
From Chrome 61, we can't get or set scrollTop, scrollLeft and like that
through "document.body" interface anymore because of changing its
implementation. And this changing killed the scrolling features. So I
replaced this interface to fix it.

To be precise, Chrome changed its implementation that "document.body"
was no longer a reflection of the viewport, and set
document.documentElement or document.scrollingElement as the viewport
instead, as a result of following the standardized spec.

Please see below for more details.
https://dev.opera.com/articles/fixing-the-scrolltop-bug/
https://drafts.csswg.org/cssom-view/#scrolling-box
https://drafts.csswg.org/cssom-view/#dom-document-scrollingelement
https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-87CD092