### PR TITLE
Ignore comment node in `Dom.isVisibleInDisplay`

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -65,7 +65,7 @@ Dom.isVisibleInDisplay = function(element) {
     // box bounding.
     for (var i = 0; i < element.childNodes.length; i++) {
       var child = element.childNodes[i];
-      if (child && child.nodeName != '#document' && child.nodeName != '#text') {
+      if (child && child.nodeName != '#document' && child.nodeName != '#text' && child.nodeName != '#comment') {
         var style = window.getComputedStyle(child, null);
         if (style && style.getPropertyValue('float') != 'none' && Dom.isVisibleInDisplay(child)) {
           return true;


### PR DESCRIPTION
If there is a dom element with only a comment element as a child, for example:

```html
<div tabindex="0"><!-- --></div>
```

The following error is thrown when trying to launch hit-a-hint:

![image](https://user-images.githubusercontent.com/80381/55466701-a8b46f80-563a-11e9-832f-61ad2488ba97.png)

There is such an element in github.com, and hit-a-hint does not work...


It seems that `Dom.isVisibleInDisplay` function should ignore also the comment elements when computing the style of `childNodes`.